### PR TITLE
Adds docs for new tagging arguments, and other improvements

### DIFF
--- a/content/reference/commands/env-create.md
+++ b/content/reference/commands/env-create.md
@@ -54,6 +54,10 @@ This command will make sure that all of these items are available, and in a stat
   >[!TIP]
   >Unless `createFrom` is specified, the branch will be created from the HEAD of the branch that backs the @concept_productionenvironment. If you would prefer to create this branch from elsewhere in the commit history, you can do so by first manually creating the branch in the remote Git repository, and then running `env:create` with the `--useExistingBranch` option.
 
+- **`--tags=name[:value][,name[:value],...]`**
+
+  One or more tags to set on the new environment. Omitting a value sets a tag with no value. Tag names may only contain alphanumeric characters, hyphens and underscores. Tag values may contain anything except newline characters. Spaces in tag values can be set using shell-specific quoting. Commas in tag values can be set by escaping them with backslash as `\,` e.g. `--tags=FullName:Payne\,Chris`.
+
 - **`-sb|--sandboxName=<sandboxName>`**
 
   Required. Prompted for if not supplied and possible to do so.

--- a/content/reference/commands/env-flowin.md
+++ b/content/reference/commands/env-flowin.md
@@ -25,6 +25,10 @@ title: env:flowin
 
   The message to be used when committing changes to the Git repository. The flow in process may create more than one commit, and the same message will be used for all commits.
 
+- **`--checkOnly`**
+
+  If specified, a *validation-only* inbound flow is performed, which means no changes will be pushed to your configured remote Git repository, and no changes will be persisted in the @concept_environmentstate. This is useful to proactively detect potential merge conflicts and collect information about which changes *would* be applied to your environment, were it to be flowed in.
+
 - **`--excludeUndeployable`**
 
   If specified, the metadata that is currently marked as undeployable in the state store is not included in the process.

--- a/content/reference/commands/env-flowout.md
+++ b/content/reference/commands/env-flowout.md
@@ -55,10 +55,9 @@ This command can also be used to validate a deployment without actually making a
 
 - **`--useLocalRepo=<directoryPath>`**
 
-If specified, OrgFlow will use an existing local repository on disk as the source of the outbound flow as opposed to creating a temporary local clone of your stack's configured remote Git repository.
+  If specified, OrgFlow will use an existing local repository on disk as the source of the outbound flow as opposed to creating a temporary local clone of your stack's configured remote Git repository.
 
- This can be useful in automation and CI/CD scenarios, such as automated validation of a pull request (where you want to validate the deployment of the merge result rather than the source environment) or other scenarios when the repository has already been cloned in previous steps.
-
+  This can be useful in automation and CI/CD scenarios, such as automated validation of a pull request (where you want to validate the deployment of the merge result rather than the source environment) or other scenarios when the repository has already been cloned in previous steps.
 
   The specified path must be a valid Git repository, and must be a recent clone of the stack's configured remote Git repository.
 

--- a/content/reference/commands/env-list.md
+++ b/content/reference/commands/env-list.md
@@ -20,14 +20,18 @@ List environments in the selected @concept_stack.
 
 - **`--withTags=name[:value][,name[:value],...]`**
 
-  List only environments matching the specified tags. Multiple tags specifiers are combined using boolean `AND` logic (i.e. only environments matching **all** specified tags are included). Tag names and tag values are matched case-insensitively. Omitting a tag value matches only tags with no value.
+  List only environments matching the specified tags. Multiple tags specifiers are combined using boolean `AND` logic (i.e. only environments matching **all** of the specified tags are included). Tag names and tag values are matched case-insensitively. Omitting a tag value matches only tags with no value. `--withTags` and `--withoutTags` specifiers are combined using boolean `AND` logic; having the same tag spec in both arguments results in no environments being listed.
+
+- **`--withoutTags=name[:value][,name[:value],...]`**
+
+  List only environments **not** matching the specified tags. Multiple tags specifiers are combined using boolean `AND` logic (i.e. only environments matching **none** of the specified tags are included). Tag names and tag values are matched case-insensitively. Omitting a tag value matches only tags with no value. `--withTags` and `--withoutTags` specifiers are combined using boolean `AND` logic; having the same tag spec in both arguments results in no environments being listed.
 
 - **`--useRegex`**
 
-  If specified, regular expression syntax can be used in tag values for more flexible matching.
+  If specified, regular expression syntax can be used in tag values in `--withTags` and `--withoutTags` arguments for more flexible matching.
 
 > [!TIP]
-> If the filtering options provided by the `--withTags` and `--useRegex` arguments are insufficient for your scenario, use the `output=json` argument to list arguments in JSON format and do your own filtering, using your scripting language or a tool such as [jq](https://stedolan.github.io/jq/).
+> If the filtering options provided by the `--withTags`, `--withoutTags` and `--useRegex` arguments are insufficient for your scenario, use the `output=json` argument to list arguments in JSON format and do your own filtering, using your scripting language or a tool such as [jq](https://stedolan.github.io/jq/).
 
 - **`--nameOnly`**
 

--- a/content/reference/commands/stack-create.md
+++ b/content/reference/commands/stack-create.md
@@ -33,7 +33,7 @@ The `stack:create` command will create a stack that contains the minimum amount 
 
   The name of the stack to be initialized. Stack names are **not** case-sensitive.
 
-- **`-e|--productionEnvironmentName=<environmentName>`**
+- **`-e|--environmentName=<environmentName>`**
 
   Required. Prompted for when not specified, and possible to do so. Defaults to `Production` if not specified.
 
@@ -98,7 +98,15 @@ The `stack:create` command will create a stack that contains the minimum amount 
 
   Required. Prompted for when not specified, and possible to do so.
 
-  The username to be used during authentication with the production Salesforce organization. This username will be used during the OAuth sign in process.
+  The username to be used to authenticate with the production Salesforce organization.
+
+- **`-p|--password=<password>`**
+
+  If supplied, then this password will be used to authenticate with the production Salesforce organization. If omitted, an interactive browser-based sign-in flow will be used.
+
+- **`--environmentTags=name[:value][,name[:value],...]`**
+
+  One or more tags to set on the production environment. Omitting a value sets a tag with no value. Tag names may only contain alphanumeric characters, hyphens and underscores. Tag values may contain anything except newline characters. Spaces in tag values can be set using shell-specific quoting. Commas in tag values can be set by escaping them with backslash as `\,` e.g. `--tags=FullName:Payne\,Chris`.
 
 - **`--saveCredentials=[Local|StateStore]`**
 
@@ -121,6 +129,10 @@ The `stack:create` command will create a stack that contains the minimum amount 
   An encryption key will be generated for you if `--saveCredentials` is specified and `--encryptionKey` is omitted.
 
   The encryption key to be used to encrypt saved credentials (if any).
+
+- **`--ensurePortable`**
+
+  By default, OrgFlow optimizes some metadata types for effective version control, at the expense of compatibility with other tools, when committing your Salesforce metadata to your Git repository. Specifying `--ensurePortable` configures your stack to instead optimize metadata in your repository for compatibility with other tools, by disabling those optimizations.
 
 - **`--apiVersion=<number>`**
 
@@ -145,5 +157,5 @@ orgflow stack:create
 Create a new stack called *NightlyBackup* with a production environment called *Prod*. Commit all metadata to a repository on GitHub, inside a folder called *metadata*. Use a custom URL to authenticate with Salesforce:
 
 ```bash
-orgflow stack:create --name=NightlyBackup --productionEnvironmentName=Prod --gitRepoUrl="git@github.com:MyOrg/MyRepo.git" --archivePath=metadata --include=All --signInUrl="https://myorg.my.salesforce.com" --username=user@orgflow.io
+orgflow stack:create --name=NightlyBackup --environmentName=Prod --gitRepoUrl="git@github.com:MyOrg/MyRepo.git" --archivePath=metadata --include=All --signInUrl="https://myorg.my.salesforce.com" --username=user@orgflow.io
 ```


### PR DESCRIPTION
- Adds docs for `env:list --withoutTags`
- Adds docs for `env:create --tags`
- Adds docs for `stack:create --environmentTags`
- Adds docs for `env:flowin --checkOnly`
- Adds missing docs for `--ensurePortable` and `--password` arguments on `stack:create`